### PR TITLE
feat: build and zip frontend

### DIFF
--- a/lib/frontend/build.js
+++ b/lib/frontend/build.js
@@ -13,6 +13,7 @@ const buildJs = require('./tasks/buildJs')
 const buildCss = require('./tasks/buildCss')
 const buildHtml = require('./tasks/buildHtml')
 const buildDependencies = require('./tasks/buildDependencies')
+const buildZip = require('../backend/tasks/buildZip')
 const { runScript } = require('../util')
 
 function createBuild (ctx, argv) {
@@ -21,18 +22,20 @@ function createBuild (ctx, argv) {
 
     if (frontend.version === 2) {
       return new Promise((resolve, reject) => {
+        console.log('Building app...')
+
         const env = ctx.env
         const envMatch = env && env.match(/^[A-Za-z0-9\-_]*$/)
 
         if (!envMatch) {
-          return console.error('environment key contains forbidden characters')
+          return reject(new Error('environment key contains forbidden characters'))
         }
 
         const name = frontend.configName
         const nameMatch = name && name.match(/^[A-Za-z0-9\-_]*$/)
 
         if (!nameMatch) {
-          return console.error('plugin name contains forbidden characters')
+          return reject(new Error('plugin name contains forbidden characters'))
         }
 
         const spawnedProcess = spawn('npm', ['run', 'build'], {
@@ -48,12 +51,15 @@ function createBuild (ctx, argv) {
 
         spawnedProcess.on('error', error => reject(error))
 
-        spawnedProcess.on('close', result => {
-          console.log(kleur.green('Done'))
-
-          resolve(result)
-        })
+        spawnedProcess.on('close', result => resolve(result))
       })
+        .then(() => {
+          console.log('Creating archive...')
+
+          return buildZip(path.resolve(process.cwd(), 'plugins', frontend.configName), 'dist')
+        })
+        .then(() => console.log(kleur.green('Done')))
+        .catch(err => console.error(err.message))
     } else {
       const src = process.cwd() + `/plugins/${frontend.configName}`
       const dest = `${process.cwd()}/maya_build/plugins/${frontend.configName}`


### PR DESCRIPTION
This alleviates the need for version 2 plugins to have to provide their own zip file, and ensures that the archiving process is cross-platform (uses `archiver` from npm, just like backend services).