### PR TITLE
Feature: Update Webhook url while backend proxy is running

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,45 @@ You can expose your local backend services to the internet using `mayan watch --
 
 Once you run mayan against a backend service the `--proxy` flag, your generated ngrok url will be displayed in the terminal and automatically copied to your clipboard. You can then use this url in your test webhook configurations or send requests to it from your frontend plugin.
 
+### stdin commands
+
+While your backend services are running, you can send these commands to mayan using stdin in the same terminal where mayan is running:
+
+`.exit` will shut down all processes gracefully (same as ctrl+C)
+
+`[backend service name]` typing the name of a service will trigger a reload of that service, similar to saving a file in that service's watched directories.
+
+> ex: to reload the `calculate` service, type "calculate" and hit enter
+
+`webhook-update [webhook ID]` will use the access token provided in your current environment to fetch the url of the webhook you specified with the second argument, then update that webhook's url to point to your ngrok tunnel, thus routing all of that webhook's traffic to your local service. **NB: this command requires the `--proxy` flag**
+
+> ex:
+> ```sh
+> $ mayan w --sd --proxy
+> # output from command indicating services are running
+> https://6e12515eb18c.ngrok.io --> copied to clipboard!
+> Inspect this connection in your browser at http://127.0.0.1:4040
+>
+> Listening on http://:::3000/workspaces/:workspaceId/:pluginNamespace/:pluginRoute
+>
+> Listening on http://:::3001/workspaces/:workspaceId/:pluginNamespace/:pluginRoute
+>
+> # user input while service is running
+> webhook-update 123456
+> # output in response to user's command
+> Successfully updated webhook url to:
+> https://6e12515eb18c.ngrok.io/workspaces/123/nameSpace/endpoint?query=param
+> ```
+>
+> alias: `wu`
+>
+> ex:
+> ```sh
+> wu 123456
+> Successfully updated webhook url to:
+> https://6e12515eb18c.ngrok.io/workspaces/123/nameSpace/endpoint?query=param
+> ```
+
 ## `maya.json` format
 
 ```js

--- a/lib/backend/tasks/updateWebhookUrl.js
+++ b/lib/backend/tasks/updateWebhookUrl.js
@@ -29,13 +29,7 @@ module.exports = async (id, ngrokUrl, ctx = {}) => {
     return console.error('Unable to update webhook')
   }
 
-  let parts = url.split(origin)
-
-  if (parts.length > 2) {
-    parts = ['', parts.slice(1).join(origin)]
-  }
-
-  const updatedUrl = parts.join(ngrokUrl)
+  const updatedUrl = url.replace(origin, ngrokUrl)
 
   // 3. PUT new webhook url
   const updateResponse = await request.put(`https://${apiEndpoint}/v1/webhooks/${id}`, {

--- a/lib/backend/tasks/updateWebhookUrl.js
+++ b/lib/backend/tasks/updateWebhookUrl.js
@@ -1,0 +1,69 @@
+const request = require('request-promise')
+const { URL } = require('url')
+
+module.exports = async (id, ngrokUrl, ctx = {}) => {
+  const {
+    apiEndpoint,
+    accessToken
+  } = ctx
+
+  // 1. GET existing webhook url
+  const res = await request.get(`https://${apiEndpoint}/v1/webhooks/${id}`, {
+    json: true,
+    headers: {
+      Authorization: `Bearer ${accessToken}`
+    }
+  })
+    .catch(err => err instanceof Error ? err : new Error(JSON.stringify(err)))
+
+  const { data: { url } = {} } = res || {}
+
+  if (res instanceof Error || typeof url !== 'string') {
+    return console.error(`Unable to GET webhook ${id}`, res)
+  }
+
+  // 2. strip out origin and replace with ngrokUrl
+  const { origin } = buildURL(url)
+
+  if (!origin) {
+    return console.error('Unable to update webhook')
+  }
+
+  let parts = url.split(origin)
+
+  if (parts.length > 2) {
+    parts = ['', parts.slice(1).join(origin)]
+  }
+
+  const updatedUrl = parts.join(ngrokUrl)
+
+  // 3. PUT new webhook url
+  const updateResponse = await request.put(`https://${apiEndpoint}/v1/webhooks/${id}`, {
+    json: true,
+    body: {
+      url: updatedUrl
+    },
+    headers: {
+      Authorization: `Bearer ${accessToken}`
+    }
+  })
+    .catch(err => err instanceof Error ? err : new Error(JSON.stringify(err)))
+
+  if (updateResponse instanceof Error) {
+    return console.error(`Unable to update webhook url: ${updateResponse}`)
+  }
+
+  const { data: { url: newUrl } = {} } = updateResponse || {}
+
+  return console.log(`Successfully updated webhook url to:\n${newUrl}`)
+}
+
+function buildURL (url) {
+  try {
+    return new URL(url)
+  } catch (e) {
+    console.error(`"${url}" is not a valid url: ${e}`)
+
+    return {}
+  }
+}

--- a/lib/backend/watch.js
+++ b/lib/backend/watch.js
@@ -140,6 +140,10 @@ module.exports = async argv => {
       const [wu, wi] = text.split(' ')
 
       if ((wu === 'wu' || wu === 'webhook-update') && wi) {
+        if (!argv.proxy) {
+          return console.error(red('You must run mayan with `--proxy` to use this feature.'))
+        }
+
         const webhookId = Number(wi)
 
         return updateWebhookUrl(webhookId, url, ctx)

--- a/lib/backend/watch.js
+++ b/lib/backend/watch.js
@@ -8,6 +8,7 @@ const { green, italic, yellow, red, bold } = require('kleur')
 const { context } = require('../context')
 const { createScriptExecutable } = require('./tasks/runScript')
 const { runWatcher } = require('./tasks/runWatcher')
+const updateWebhookUrl = require('./tasks/updateWebhookUrl')
 const { printErrorAndAbort, runScript } = require('../util')
 
 const onProxyError = printErrorAndAbort('backend http proxy')
@@ -17,6 +18,8 @@ module.exports = async argv => {
   const ctx = await context(argv).catch(err => err instanceof Error ? err : new Error(err))
 
   if (ctx instanceof Error) throw ctx
+
+  const accessToken = ctx.accessToken || null
 
   let portIncrementer = 0
 
@@ -94,8 +97,6 @@ module.exports = async argv => {
   const server = http.createServer((req, res) => {
     const urlServicePath = urlModule.parse(req.url).pathname.split('/').slice(3, 5).join('/')
 
-    const accessToken = ctx.accessToken || null
-
     for (const service of liveServices) {
       if (urlServicePath === service.namespaceRoute) {
         const headerKeys = ['x-firebase-url', 'x-firebase-secret', 'x-plugin', 'x-plugin-draft', 'x-zengine-webhook-key']
@@ -134,7 +135,15 @@ module.exports = async argv => {
     process.stdin.on('data', buffer => {
       const text = buffer.toString().trim()
 
-      if (text === '.exit') process.emit('cleanup')
+      if (text === '.exit') return process.emit('cleanup')
+
+      const [wu, wi] = text.split(' ')
+
+      if (wu === 'wu' && wi) {
+        const webhookId = Number(wi)
+
+        return updateWebhookUrl(webhookId, url, ctx)
+      }
 
       liveServices.forEach(srv => {
         if (text === srv.configName) {

--- a/lib/backend/watch.js
+++ b/lib/backend/watch.js
@@ -139,7 +139,7 @@ module.exports = async argv => {
 
       const [wu, wi] = text.split(' ')
 
-      if (wu === 'wu' && wi) {
+      if ((wu === 'wu' || wu === 'webhook-update') && wi) {
         const webhookId = Number(wi)
 
         return updateWebhookUrl(webhookId, url, ctx)


### PR DESCRIPTION
This feature allows the user to provide a webhook ID (using stdin via shell) while a backend service is running with ngrok proxy, which mayan will then use to retrieve the url of that webhook and substitute the origin for the current ngrok origin.

Example:

```sh
$ mayan w --sd --proxy -b

# initial output
https://6e12515eb18c.ngrok.io --> copied to clipboard!
Inspect this connection in your browser at http://127.0.0.1:4040

Listening on http://:::3000/workspaces/:workspaceId/:pluginNamespace/:pluginRoute

Listening on http://:::3001/workspaces/:workspaceId/:pluginNamespace/:pluginRoute

# user input while service is running
webhook-update 123456
# output in response to user's command
Successfully updated webhook url to:
https://6e12515eb18c.ngrok.io/workspaces/123/nameSpace/endpoint?query=param
```